### PR TITLE
Add rebel tags via public

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       rake (< 13.0)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    devise (4.7.0)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -257,7 +257,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.1.9)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby

--- a/app/services/rebels/create_service.rb
+++ b/app/services/rebels/create_service.rb
@@ -81,7 +81,8 @@ module Rebels
         :notes,
         :phone,
         :postcode,
-        :redirect
+        :redirect,
+        :tag_list
       )
     end
 

--- a/test/fixtures/acts_as_taggable_on/taggings.yml
+++ b/test/fixtures/acts_as_taggable_on/taggings.yml
@@ -1,0 +1,12 @@
+alice-sneezy:
+  taggable: alice
+  tag: sneezy
+alice-dopey:
+  taggable: alice
+  tag: dopey
+bob-sneezy:
+  taggable: bob
+  tag: sneezy
+bob-bashful:
+  taggable: bob
+  tag: bashful

--- a/test/fixtures/acts_as_taggable_on/tags.yml
+++ b/test/fixtures/acts_as_taggable_on/tags.yml
@@ -1,0 +1,11 @@
+sneezy:
+  name: sneezy
+
+bashful:
+  name: bashful
+
+dopey:
+  name: dopey
+
+grumpy:
+  name: grumpy

--- a/test/fixtures/local_groups.yml
+++ b/test/fixtures/local_groups.yml
@@ -12,8 +12,10 @@
 
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+namur:
+  id: 1
+  name: Namur
 
-two:
-  name: MyString
+liege:
+  id: 7
+  name: Liège

--- a/test/fixtures/rebels.yml
+++ b/test/fixtures/rebels.yml
@@ -23,16 +23,38 @@
 
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  email: MyString
-  phone: MyString
-  notes: MyText
-  on_basecamp: false
+alice:
+  name: Alice
+  email: alice@example.org
+  phone: 11223344
+  notes: Alice is the first rebel
+  on_basecamp: true
+  local_group: liege
+  language: fr
 
-two:
-  name: MyString
-  email: MyString
-  phone: MyString
-  notes: MyText
+bob:
+  name: Bob
+  email: bob@example.org
+  phone: 12341234
+  notes: Bob is a friend of Anne
   on_basecamp: false
+  local_group: liege
+  language: fr
+
+carol:
+  name: Carol
+  email: carol@example.org
+  phone: 43214321
+  notes: Carol likes chocolate
+  on_basecamp: false
+  local_group: namur
+  language: fr
+
+dan:
+  name: Dan
+  email: dan@example.org
+  phone: 43214321
+  notes: Dan dances daily
+  on_basecamp: false
+  local_group: namur
+  language: fr

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -28,8 +28,11 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  email: admin@localhost
+  admin: true
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'admin') %>
+two:
+  email: user@localhost
+  admin: false
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'user') %>


### PR DESCRIPTION
This change allows us to auto-add tags to rebels who subscribe through the website