### PR TITLE
Add rebels to workgroups

### DIFF
--- a/app/views/rebels/_form.html.slim
+++ b/app/views/rebels/_form.html.slim
@@ -72,16 +72,15 @@
               label: "Specific skills/experience/resources OR thoughts/questions",
               required: false
 
-    - if f.object.local_group&.working_groups&.any?
+    - if current_user.local_group&.working_groups&.any?
       = section_heading heading: "Working Groups",
                         spacing: :spacer
 
       = f.input :working_group_ids,
                 as: :check_boxes,
                 wrapper: :foundation_radio_buttons,
-                collection: f.object.local_group&.working_groups,
+                collection: current_user.local_group.working_groups,
                 label: ""
-
 
     = section_heading heading: "Management",
                     spacing: :spacer


### PR DESCRIPTION
- allow rebels to be added to workgroups on create
- previously rebels had to be created and then added
  to the workgroups

Issue #86 