### PR TITLE
Push data to Mailtrain in order to create relevant segments

### DIFF
--- a/app/controllers/local_groups_controller.rb
+++ b/app/controllers/local_groups_controller.rb
@@ -30,7 +30,7 @@ class LocalGroupsController < BaseController
 
   def update
     service = LocalGroups::UpdateService.new(
-      local_group: LocalGroup.find(params[:id])
+      local_group: @local_group
     )
     if service.run(params)
       redirect_to local_group_path(service.local_group),
@@ -54,13 +54,13 @@ class LocalGroupsController < BaseController
 
   private
 
+  def get_local_group
+    @local_group = LocalGroup.find(params[:id])
+  end
+
   def set_presenters
     @menu_presenter = Components::MenuPresenter.new(
       active_primary: "local_groups"
     )
-  end
-
-  def get_local_group
-    @local_group = LocalGroup.find(params[:id])
   end
 end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,12 +1,9 @@
 class SkillsController < BaseController
   before_action :redirect_unless_admin
+  before_action :get_skill, only: [:show, :edit, :update, :destroy]
 
   def index
     @skills = Skill.all.order(:name)
-  end
-
-  def show
-    @skill = Skill.find(params[:id])
   end
 
   def new
@@ -14,25 +11,30 @@ class SkillsController < BaseController
   end
 
   def create
-    @skill = Skill.new(skill_params)
-    if @skill.save
-      redirect_to skill_path(@skill),
-                  notice: "New skill added successfully."
+    service = Skills::CreateService.new
+    if service.run(params)
+      redirect_to skill_path(service.skill),
+                  notice: "Skill added successfully."
     else
+      @skill = service.skill
+      set_error_flash(service.skill, service.error_message)
       render :new
     end
   end
 
   def edit
-    @skill = Skill.find(params[:id])
   end
 
   def update
-    @skill = Skill.find(params[:id])
-    if @skill.update(skill_params)
-      redirect_to skill_path(@skill),
+    service = Skills::UpdateService.new(
+      skill: @skill
+    )
+    if service.run(params)
+      redirect_to skill_path(service.skill),
                   notice: "The skill has been updated."
     else
+      @skill = service.skill
+      set_error_flash(service.skill, service.error_message)
       render :edit
     end
   end
@@ -50,16 +52,13 @@ class SkillsController < BaseController
 
   private
 
+  def get_skill
+    @skill = Skill.find(params[:id])
+  end
+
   def set_presenters
     @menu_presenter = Components::MenuPresenter.new(
       active_primary: "skills"
-    )
-  end
-
-  def skill_params
-    params.require(:skill).permit(
-      :description,
-      :name
     )
   end
 end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -40,13 +40,13 @@ class SkillsController < BaseController
   end
 
   def destroy
-    @skill = Skill.find(params[:id])
-    if @skill.destroy
+    service = Skills::DeleteService.new(skill: @skill)
+    if service.run!
       redirect_to skills_path,
                   notice: "The skill has been deleted."
     else
-      flash.now[:alert] = "We're sorry but this skill cannot be deleted."
-      render :show
+      redirect_to skill_path(service.skill),
+                  alert: "We're sorry but this skill cannot be deleted."
     end
   end
 

--- a/app/controllers/working_groups_controller.rb
+++ b/app/controllers/working_groups_controller.rb
@@ -1,10 +1,11 @@
 class WorkingGroupsController < BaseController
+  before_action :get_working_group, only: [:show, :edit, :update, :destroy]
+
   def index
     @working_groups = WorkingGroup.all.order(:local_group_id)
   end
 
   def show
-    @working_group = WorkingGroup.find(params[:id])
   end
 
   def new
@@ -12,42 +13,43 @@ class WorkingGroupsController < BaseController
   end
 
   def create
-    @working_group = WorkingGroup.new(working_group_params)
-    if @working_group.save
-      redirect_to working_group_path(@working_group),
+    service = WorkingGroups::CreateService.new
+    if service.run(params)
+      redirect_to working_group_path(service.working_group),
                   notice: "Congrats, we have a new working group!"
     else
+      @working_group = service.working_group
+      set_error_flash(service.working_group, service.error_message)
       render :new
     end
   end
 
   def edit
-    @working_group = WorkingGroup.find(params[:id])
   end
 
   def update
-    @working_group = WorkingGroup.find(params[:id])
-    if @working_group.update(working_group_params)
-      redirect_to working_group_path(@working_group),
+    service = WorkingGroups::UpdateService.new(
+      working_group: @working_group
+    )
+    if service.run(params)
+      redirect_to working_group_path(service.working_group),
                   notice: "The working group has been updated."
     else
+      @working_group = service.working_group
+      set_error_flash(service.working_group, service.error_message)
       render :edit
     end
   end
 
   private
 
+  def get_working_group
+    @working_group = WorkingGroup.find(params[:id])
+  end
+
   def set_presenters
     @menu_presenter = Components::MenuPresenter.new(
       active_primary: 'working_groups'
-    )
-  end
-
-  def working_group_params
-    params.require(:working_group).permit(
-      :color,
-      :local_group_id,
-      :name
     )
   end
 end

--- a/app/javascript/css/components/form.scss
+++ b/app/javascript/css/components/form.scss
@@ -54,6 +54,10 @@
           font-size: rem-calc(24);
           height: 4rem;
         }
+
+        &.uppercase {
+          text-transform: uppercase;
+        }
       }
 
       .label-text {

--- a/app/jobs/mailtrain/add_subscriptions_job.rb
+++ b/app/jobs/mailtrain/add_subscriptions_job.rb
@@ -19,8 +19,8 @@ class Mailtrain::AddSubscriptionsJob < ActiveJob::Base
         "MERGE_POSTCODE": rebel.postcode,
         "MERGE_PROFILE_URL": rebel.profile_url,
         "MERGE_TAGS": rebel.tag_list,
-        "MERGE_SKILLS": rebel.skills&.pluck(:name)&.join("|"),
-        "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:name)&.join("|"),
+        "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
+        "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
         "FORCE_SUBSCRIBE": "yes",
         "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
       }
@@ -38,8 +38,8 @@ class Mailtrain::AddSubscriptionsJob < ActiveJob::Base
         "MERGE_POSTCODE": rebel.postcode,
         "MERGE_PROFILE_URL": rebel.profile_url,
         "MERGE_TAGS": rebel.tag_list,
-        "MERGE_SKILLS": rebel.skills&.pluck(:name)&.join("|"),
-        "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:name)&.join("|"),
+        "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
+        "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
         "FORCE_SUBSCRIBE": "yes",
         "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
       }

--- a/app/models/rebel.rb
+++ b/app/models/rebel.rb
@@ -5,7 +5,6 @@
 #  id                         :bigint           not null, primary key
 #  availability               :string
 #  consent                    :boolean
-#  email                      :string
 #  email_bidx                 :string
 #  email_ciphertext           :string
 #  interests                  :string
@@ -15,7 +14,6 @@
 #  name                       :string
 #  notes                      :text
 #  number_of_arrests          :integer
-#  phone                      :string
 #  phone_bidx                 :string
 #  phone_ciphertext           :string
 #  postcode                   :string

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -14,7 +14,7 @@ class Skill < ApplicationRecord
   has_many :rebel_skills
   has_many :rebels, through: :rebel_skills
 
-  validates :code, uniqueness: {
+  validates :code, presence: true, uniqueness: {
     message: "This code has already been used, please use another."
   }
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -13,4 +13,8 @@
 class Skill < ApplicationRecord
   has_many :rebel_skills
   has_many :rebels, through: :rebel_skills
+
+  validates :code, uniqueness: {
+    message: "This code has already been used, please use another."
+  }
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -3,8 +3,9 @@
 # Table name: skills
 #
 #  id          :bigint           not null, primary key
-#  name        :string
+#  code        :string
 #  description :text
+#  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@
 #  admin                  :boolean
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
-#  email                  :string           default(""), not null
 #  email_bidx             :string
 #  email_ciphertext       :string
 #  encrypted_password     :string           default(""), not null
@@ -14,6 +13,16 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
 #  locked_at              :datetime
+#  otp_auth_secret        :string
+#  otp_challenge_expires  :datetime
+#  otp_enabled            :boolean          default(FALSE), not null
+#  otp_enabled_on         :datetime
+#  otp_failed_attempts    :integer          default(0), not null
+#  otp_mandatory          :boolean          default(FALSE), not null
+#  otp_persistence_seed   :string
+#  otp_recovery_counter   :integer          default(0), not null
+#  otp_recovery_secret    :string
+#  otp_session_challenge  :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/app/models/working_group.rb
+++ b/app/models/working_group.rb
@@ -3,6 +3,7 @@
 # Table name: working_groups
 #
 #  id             :bigint           not null, primary key
+#  code           :string
 #  color          :string
 #  name           :string
 #  created_at     :datetime         not null

--- a/app/models/working_group.rb
+++ b/app/models/working_group.rb
@@ -17,7 +17,7 @@ class WorkingGroup < ApplicationRecord
   has_many :working_group_enrollments
   has_many :rebels, through: :working_group_enrollments
 
-  validates :code, uniqueness: {
+  validates :code, presence: true, uniqueness: {
     scope: :local_group_id,
     message: "This code has already been used, please use another."
   }

--- a/app/models/working_group.rb
+++ b/app/models/working_group.rb
@@ -16,4 +16,9 @@ class WorkingGroup < ApplicationRecord
 
   has_many :working_group_enrollments
   has_many :rebels, through: :working_group_enrollments
+
+  validates :code, uniqueness: {
+    scope: :local_group_id,
+    message: "This code has already been used, please use another."
+  }
 end

--- a/app/services/skills/create_service.rb
+++ b/app/services/skills/create_service.rb
@@ -19,7 +19,7 @@ module Skills
 
     def run!(params = {})
       skill.attributes = skill_params(params)
-      skill.code.upcase!
+      skill.code&.upcase!
       skill.save!
       true
     end

--- a/app/services/skills/create_service.rb
+++ b/app/services/skills/create_service.rb
@@ -1,0 +1,39 @@
+module Skills
+  class CreateService < ServiceBase
+    attr_reader :skill
+
+    def initialize
+      @skill = Skill.new
+      @report_errors = true
+    end
+
+    def run(params = {})
+      context = {
+        params: params
+      }
+
+      catch_error(context: context) do
+        run!(params)
+      end
+    end
+
+    def run!(params = {})
+      skill.attributes = skill_params(params)
+      skill.code.upcase!
+      skill.save!
+      true
+    end
+
+    private
+
+    def skill_params(params)
+      params
+        .require(:skill)
+        .permit(
+          :description,
+          :name,
+          :code
+        )
+    end
+  end
+end

--- a/app/services/skills/delete_service.rb
+++ b/app/services/skills/delete_service.rb
@@ -1,0 +1,29 @@
+module Skills
+  class DeleteService < ServiceBase
+    attr_reader :skill
+
+    def initialize(skill:)
+      @skill = skill
+    end
+
+    def run
+      catch_error do
+        run!
+      end
+    end
+
+    def run!
+      skill_rebels_ids = skill.rebels.pluck(:id)
+      skill.destroy
+
+      # update subscriptions
+      rebels = Rebel.find(skill_rebels_ids)
+      rebels.each do |rebel|
+        Mailtrain::DeleteSubscriptionsJob.perform_later(rebel.email, rebel.local_group&.id)
+        Mailtrain::AddSubscriptionsJob.perform_later(rebel)
+      end
+
+      true
+    end
+  end
+end

--- a/app/services/skills/update_service.rb
+++ b/app/services/skills/update_service.rb
@@ -19,7 +19,7 @@ module Skills
 
     def run!(params = {})
       skill.attributes = skill_params(params)
-      skill.code.upcase!
+      skill.code.&upcase!
       skill.save!
 
       # update all subscriptions

--- a/app/services/skills/update_service.rb
+++ b/app/services/skills/update_service.rb
@@ -21,6 +21,13 @@ module Skills
       skill.attributes = skill_params(params)
       skill.code.upcase!
       skill.save!
+
+      # update all subscriptions
+      skill.rebels.each do |rebel|
+        Mailtrain::DeleteSubscriptionsJob.perform_later(rebel.email, rebel.local_group&.id)
+        Mailtrain::AddSubscriptionsJob.perform_later(rebel)
+      end
+
       true
     end
 

--- a/app/services/skills/update_service.rb
+++ b/app/services/skills/update_service.rb
@@ -1,9 +1,9 @@
-module WorkingGroups
+module Skills
   class UpdateService < ServiceBase
-    attr_reader :working_group
+    attr_reader :skill
 
-    def initialize(working_group:)
-      @working_group = working_group
+    def initialize(skill:)
+      @skill = skill
       @report_errors = true
     end
 
@@ -18,20 +18,19 @@ module WorkingGroups
     end
 
     def run!(params = {})
-      working_group.attributes = working_group_params(params)
-      working_group.code.upcase!
-      working_group.save!
+      skill.attributes = skill_params(params)
+      skill.code.upcase!
+      skill.save!
       true
     end
 
     private
 
-    def working_group_params(params)
+    def skill_params(params)
       params
-        .require(:working_group)
+        .require(:skill)
         .permit(
-          :color,
-          :local_group_id,
+          :description,
           :name,
           :code
         )

--- a/app/services/working_groups/create_service.rb
+++ b/app/services/working_groups/create_service.rb
@@ -1,0 +1,40 @@
+module WorkingGroups
+  class CreateService < ServiceBase
+    attr_reader :working_group
+
+    def initialize
+      @working_group = WorkingGroup.new
+      @report_errors = true
+    end
+
+    def run(params = {})
+      context = {
+        params: params
+      }
+
+      catch_error(context: context) do
+        run!(params)
+      end
+    end
+
+    def run!(params = {})
+      working_group.attributes = working_group_params(params)
+      working_group.code.upcase!
+      working_group.save!
+      true
+    end
+
+    private
+
+    def working_group_params(params)
+      params
+        .require(:working_group)
+        .permit(
+          :color,
+          :local_group_id,
+          :name,
+          :code
+        )
+    end
+  end
+end

--- a/app/services/working_groups/create_service.rb
+++ b/app/services/working_groups/create_service.rb
@@ -19,7 +19,7 @@ module WorkingGroups
 
     def run!(params = {})
       working_group.attributes = working_group_params(params)
-      working_group.code.upcase!
+      working_group.code&.upcase!
       working_group.save!
       true
     end

--- a/app/services/working_groups/update_service.rb
+++ b/app/services/working_groups/update_service.rb
@@ -1,0 +1,42 @@
+module WorkingGroups
+  class UpdateService < ServiceBase
+    PreconditionFailedError = Class.new(StandardError)
+
+    attr_reader :working_group
+
+    def initialize(working_group:)
+      @working_group = working_group
+      @report_errors = true
+    end
+
+    def run(params = {})
+      context = {
+        params: params
+      }
+
+      catch_error(context: context) do
+        run!(params)
+      end
+    end
+
+    def run!(params = {})
+      working_group.attributes = working_group_params(params)
+      working_group.code.upcase!
+      working_group.save!
+      true
+    end
+
+    private
+
+    def working_group_params(params)
+      params
+        .require(:working_group)
+        .permit(
+          :color,
+          :local_group_id,
+          :name,
+          :code
+        )
+    end
+  end
+end

--- a/app/services/working_groups/update_service.rb
+++ b/app/services/working_groups/update_service.rb
@@ -21,6 +21,13 @@ module WorkingGroups
       working_group.attributes = working_group_params(params)
       working_group.code.upcase!
       working_group.save!
+
+      # update all subscriptions
+      working_group.rebels.each do |rebel|
+        Mailtrain::DeleteSubscriptionsJob.perform_later(rebel.email, rebel.local_group&.id)
+        Mailtrain::AddSubscriptionsJob.perform_later(rebel)
+      end
+
       true
     end
 

--- a/app/services/working_groups/update_service.rb
+++ b/app/services/working_groups/update_service.rb
@@ -19,7 +19,7 @@ module WorkingGroups
 
     def run!(params = {})
       working_group.attributes = working_group_params(params)
-      working_group.code.upcase!
+      working_group.code&.upcase!
       working_group.save!
 
       # update all subscriptions

--- a/app/views/skills/_form.html.slim
+++ b/app/views/skills/_form.html.slim
@@ -10,3 +10,9 @@
           input_html: { rows: 3 },
           label: "Skill description",
           required: false
+
+= f.input :code,
+          label: "Code",
+          hint: "3 characters, required for creating segments on Mailtrain",
+          required: true,
+          input_html: { pattern: "^[a-zA-Z0-9]{3}$", class: "uppercase" }

--- a/app/views/skills/index.html.slim
+++ b/app/views/skills/index.html.slim
@@ -21,5 +21,8 @@ table
         td
           = link_to skill.name,
                     skill_path(skill)
+          - if skill.code.present?
+            small
+              |  (#{skill.code})
         td
           = skill.rebels.size

--- a/app/views/skills/show.html.slim
+++ b/app/views/skills/show.html.slim
@@ -27,3 +27,10 @@
       strong Description
       br
       = simple_format @skill.description
+
+    p
+      strong Code
+      br
+      small The code is used when creating segments on Mailtrain
+      br
+      = @skill.code

--- a/app/views/working_groups/_form.html.slim
+++ b/app/views/working_groups/_form.html.slim
@@ -15,3 +15,9 @@
 = f.input :color,
           label: "Color",
           hint: "eg. #CC1234"
+
+= f.input :code,
+          label: "Code",
+          hint: "3 characters, required for creating segments on Mailtrain",
+          required: true,
+          input_html: { pattern: "^[a-zA-Z0-9]{3}$", class: "uppercase" }

--- a/app/views/working_groups/index.html.slim
+++ b/app/views/working_groups/index.html.slim
@@ -24,5 +24,8 @@ table
           | /
           =< link_to working_group.name,
                     working_group_path(working_group)
+          - if working_group.code.present?
+            small
+              |  (#{working_group.code})
         td
           = working_group.rebels.size

--- a/app/views/working_groups/show.html.slim
+++ b/app/views/working_groups/show.html.slim
@@ -24,4 +24,13 @@
     p
       strong Color
       br
+      small The color is used on the rebels table
+      br
       = @working_group.color
+
+    p
+      strong Code
+      br
+      small The code is used when creating segments on Mailtrain
+      br
+      = @working_group.code

--- a/db/migrate/20191127043406_add_code_to_working_groups.rb
+++ b/db/migrate/20191127043406_add_code_to_working_groups.rb
@@ -1,0 +1,5 @@
+class AddCodeToWorkingGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :working_groups, :code, :string
+  end
+end

--- a/db/migrate/20191127043415_add_code_to_skills.rb
+++ b/db/migrate/20191127043415_add_code_to_skills.rb
@@ -1,0 +1,5 @@
+class AddCodeToSkills < ActiveRecord::Migration[6.0]
+  def change
+    add_column :skills, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_23_052405) do
+ActiveRecord::Schema.define(version: 2019_11_27_043415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,11 +82,11 @@ ActiveRecord::Schema.define(version: 2019_10_23_052405) do
     t.string "token"
     t.datetime "self_updated_at"
     t.string "availability"
+    t.integer "number_of_arrests"
     t.string "email_ciphertext"
     t.string "email_bidx"
     t.string "phone_ciphertext"
     t.string "phone_bidx"
-    t.integer "number_of_arrests"
     t.index ["email_bidx"], name: "index_rebels_on_email_bidx", unique: true
     t.index ["local_group_id"], name: "index_rebels_on_local_group_id"
     t.index ["phone_bidx"], name: "index_rebels_on_phone_bidx"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_052405) do
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "code"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
@@ -143,10 +144,22 @@ ActiveRecord::Schema.define(version: 2019_10_23_052405) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "local_group_id"
     t.boolean "admin"
+    t.string "otp_auth_secret"
+    t.string "otp_recovery_secret"
+    t.boolean "otp_enabled", default: false, null: false
+    t.boolean "otp_mandatory", default: false, null: false
+    t.datetime "otp_enabled_on"
+    t.integer "otp_failed_attempts", default: 0, null: false
+    t.integer "otp_recovery_counter", default: 0, null: false
+    t.string "otp_persistence_seed"
+    t.string "otp_session_challenge"
+    t.datetime "otp_challenge_expires"
     t.string "email_ciphertext"
     t.string "email_bidx"
     t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["local_group_id"], name: "index_users_on_local_group_id"
+    t.index ["otp_challenge_expires"], name: "index_users_on_otp_challenge_expires"
+    t.index ["otp_session_challenge"], name: "index_users_on_otp_session_challenge", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
@@ -166,6 +179,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_052405) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "color"
+    t.string "code"
     t.index ["local_group_id"], name: "index_working_groups_on_local_group_id"
   end
 

--- a/lib/tasks/mailtrain.rake
+++ b/lib/tasks/mailtrain.rake
@@ -14,8 +14,8 @@ namespace :mailtrain do
           "MERGE_POSTCODE": rebel.postcode,
           "MERGE_PROFILE_URL": rebel.profile_url,
           "MERGE_TAGS": rebel.tag_list,
-          "MERGE_SKILLS": rebel.skills&.pluck(:name)&.join("|"),
-          "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:name)&.join("|"),
+          "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
+          "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
           "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
         }
       )
@@ -30,8 +30,8 @@ namespace :mailtrain do
             "MERGE_POSTCODE": rebel.postcode,
             "MERGE_PROFILE_URL": rebel.profile_url,
             "MERGE_TAGS": rebel.tag_list,
-            "MERGE_SKILLS": rebel.skills&.pluck(:name)&.join("|"),
-            "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:name)&.join("|"),
+            "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
+            "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
             "FORCE_SUBSCRIBE": "yes",
             "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
           }

--- a/spec/factories/local_groups.rb
+++ b/spec/factories/local_groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :local_group do
+    name { FFaker::Address.unique.city }
+  end
+end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :skill do
+    name { FFaker::Skill.specialty }
+    code { rand(36**3).to_s(36).upcase }
+  end
+end

--- a/spec/factories/working_groups.rb
+++ b/spec/factories/working_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :working_group do
+    local_group
+    name { FFaker::Skill.specialty }
+    code { rand(36**3).to_s(36).upcase }
+  end
+end

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Skill, "validations" do
+  let(:skill) { create(:skill) }
+
+  it "is valid with valid attributes" do
+    expect(skill).to be_valid
+  end
+
+  it "isn't valid if code is missing" do
+    skill.code = nil
+    skill.valid?
+    expect(skill.errors.count).to eq 1
+  end
+end
+
+RSpec.describe Skill, "on_update" do
+  it "can't be updated if code is already used" do
+    skill1 = create(:skill, code: "ABC")
+    skill2 = create(:skill, code: "QWE")
+    skill1.update(code: "QWE")
+    expect(skill1.errors.count).to eq 1
+  end
+end

--- a/spec/models/working_group_spec.rb
+++ b/spec/models/working_group_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe WorkingGroup, "validations" do
+  let(:working_group) { create(:working_group) }
+
+  it "is valid with valid attributes" do
+    expect(working_group).to be_valid
+  end
+
+  it "isn't valid if code is missing" do
+    working_group.code = nil
+    working_group.valid?
+    expect(working_group.errors.count).to eq 1
+  end
+end
+
+RSpec.describe WorkingGroup, "on_update" do
+  it "can't be updated if code is already used at the local group level" do
+    local_group = create(:local_group)
+    working_group1 = create(:working_group, local_group: local_group, code: "ABC")
+    working_group2 = create(:working_group, local_group: local_group, code: "QWE")
+    working_group1.update(code: "QWE")
+    expect(working_group1.errors.count).to eq 1
+  end
+end

--- a/spec/services/skills/create_service_spec.rb
+++ b/spec/services/skills/create_service_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Skills::CreateService, "#run" do
+  describe "When code is missing" do
+    it "doesn't create the skill" do
+      params = ActionController::Parameters.new({
+        skill: {
+          name: FFaker::Skill.specialty
+        }
+      })
+
+      service = Skills::CreateService.new
+      service.run(params)
+
+      expect(Skill.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/working_groups/create_service_spec.rb
+++ b/spec/services/working_groups/create_service_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe WorkingGroups::CreateService, "#run" do
+  describe "When code is missing" do
+    it "doesn't create the working group" do
+      local_group = create(:local_group)
+
+      params = ActionController::Parameters.new({
+        working_group: {
+          local_group_id: local_group.id,
+          name: "Regenerative Culture"
+        }
+      })
+
+      service = WorkingGroups::CreateService.new
+      service.run(params)
+
+      expect(WorkingGroup.count).to eq(0)
+    end
+  end
+end

--- a/test/fixtures/rebels.yml
+++ b/test/fixtures/rebels.yml
@@ -5,7 +5,6 @@
 #  id                         :bigint           not null, primary key
 #  availability               :string
 #  consent                    :boolean
-#  email                      :string
 #  email_bidx                 :string
 #  email_ciphertext           :string
 #  interests                  :string
@@ -15,7 +14,6 @@
 #  name                       :string
 #  notes                      :text
 #  number_of_arrests          :integer
-#  phone                      :string
 #  phone_bidx                 :string
 #  phone_ciphertext           :string
 #  postcode                   :string

--- a/test/fixtures/skills.yml
+++ b/test/fixtures/skills.yml
@@ -3,8 +3,9 @@
 # Table name: skills
 #
 #  id          :bigint           not null, primary key
-#  name        :string
+#  code        :string
 #  description :text
+#  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,7 +6,6 @@
 #  admin                  :boolean
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
-#  email                  :string           default(""), not null
 #  email_bidx             :string
 #  email_ciphertext       :string
 #  encrypted_password     :string           default(""), not null
@@ -14,6 +13,16 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
 #  locked_at              :datetime
+#  otp_auth_secret        :string
+#  otp_challenge_expires  :datetime
+#  otp_enabled            :boolean          default(FALSE), not null
+#  otp_enabled_on         :datetime
+#  otp_failed_attempts    :integer          default(0), not null
+#  otp_mandatory          :boolean          default(FALSE), not null
+#  otp_persistence_seed   :string
+#  otp_recovery_counter   :integer          default(0), not null
+#  otp_recovery_secret    :string
+#  otp_session_challenge  :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/test/fixtures/working_groups.yml
+++ b/test/fixtures/working_groups.yml
@@ -3,6 +3,7 @@
 # Table name: working_groups
 #
 #  id             :bigint           not null, primary key
+#  code           :string
 #  color          :string
 #  name           :string
 #  created_at     :datetime         not null

--- a/test/models/rebel_test.rb
+++ b/test/models/rebel_test.rb
@@ -5,7 +5,6 @@
 #  id                         :bigint           not null, primary key
 #  availability               :string
 #  consent                    :boolean
-#  email                      :string
 #  email_bidx                 :string
 #  email_ciphertext           :string
 #  interests                  :string
@@ -15,7 +14,6 @@
 #  name                       :string
 #  notes                      :text
 #  number_of_arrests          :integer
-#  phone                      :string
 #  phone_bidx                 :string
 #  phone_ciphertext           :string
 #  postcode                   :string

--- a/test/models/skill_test.rb
+++ b/test/models/skill_test.rb
@@ -3,8 +3,9 @@
 # Table name: skills
 #
 #  id          :bigint           not null, primary key
-#  name        :string
+#  code        :string
 #  description :text
+#  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,7 +6,6 @@
 #  admin                  :boolean
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
-#  email                  :string           default(""), not null
 #  email_bidx             :string
 #  email_ciphertext       :string
 #  encrypted_password     :string           default(""), not null
@@ -14,6 +13,16 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
 #  locked_at              :datetime
+#  otp_auth_secret        :string
+#  otp_challenge_expires  :datetime
+#  otp_enabled            :boolean          default(FALSE), not null
+#  otp_enabled_on         :datetime
+#  otp_failed_attempts    :integer          default(0), not null
+#  otp_mandatory          :boolean          default(FALSE), not null
+#  otp_persistence_seed   :string
+#  otp_recovery_counter   :integer          default(0), not null
+#  otp_recovery_secret    :string
+#  otp_session_challenge  :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/test/models/working_group_test.rb
+++ b/test/models/working_group_test.rb
@@ -3,6 +3,7 @@
 # Table name: working_groups
 #
 #  id             :bigint           not null, primary key
+#  code           :string
 #  color          :string
 #  name           :string
 #  created_at     :datetime         not null


### PR DESCRIPTION
##### Description
Add `working_group.code` and `skill.code` attributes to reduce length of data sent to Mailtrain, otherwise we end up using `longtext` custom fields on Mailtrain, and these ones cannot be used for creating segments.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Changes don't break existing behavior
- [ ] Tests coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->
No specs.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: https://github.com/extinctionrebellion/RebelsManager/issues/114