### PR TITLE
Provide more details to Mailtrain so that it can stop sending welcome emails on updates

### DIFF
--- a/app/jobs/mailtrain/add_subscriptions_job.rb
+++ b/app/jobs/mailtrain/add_subscriptions_job.rb
@@ -14,7 +14,7 @@ class Mailtrain::AddSubscriptionsJob < ActiveJob::Base
       {
         "EMAIL": rebel.email,
         "MERGE_NAME": rebel.name,
-        "MERGE_SUBSCRIPTION_DATE": rebel.created_at.to_date.to_s,
+        "MERGE_SUBSCRIPTION_DATE": rebel.created_at.to_date.strftime("%d/%m/%Y"),
         "MERGE_LOCAL_GROUP": rebel.local_group&.name,
         "MERGE_LANGUAGE": rebel.language,
         "MERGE_POSTCODE": rebel.postcode,

--- a/app/models/rebel.rb
+++ b/app/models/rebel.rb
@@ -27,6 +27,7 @@
 #  status                     :string
 #  tags                       :text
 #  token                      :string
+#  version                    :integer
 #  willingness_to_be_arrested :boolean
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/app/services/rebels/create_service.rb
+++ b/app/services/rebels/create_service.rb
@@ -35,6 +35,7 @@ module Rebels
       end
       validate_email_format! if @rebel.valid?
       generate_token
+      set_version
       delete_existing_rebel_if_no_local_group(@rebel.email)
       @rebel.save!
       Mailtrain::AddSubscriptionsJob.perform_later(@rebel)
@@ -110,6 +111,12 @@ module Rebels
         :active,
         skill_ids: [],
       )
+    end
+
+    def set_version
+      # we use this for solving the Mailtrain issue with welcome emails
+      # (welcome emails are sent to rebels with version == 1)
+      rebel.version = 1
     end
 
     def validate_email_format!

--- a/app/services/rebels/update_service.rb
+++ b/app/services/rebels/update_service.rb
@@ -23,6 +23,7 @@ module Rebels
       current_local_group = rebel.local_group
       rebel.attributes = rebel_params(params)
       validate_email_format!
+      increment_version
       rebel.save!
       Mailtrain::DeleteSubscriptionsJob.perform_later(current_email, current_local_group&.id)
       Mailtrain::AddSubscriptionsJob.perform_later(rebel)
@@ -31,6 +32,10 @@ module Rebels
     end
 
     private
+
+    def increment_version
+      rebel.version += 1
+    end
 
     def rebel_params(params)
       params

--- a/db/migrate/20200224041822_add_version_to_rebel.rb
+++ b/db/migrate/20200224041822_add_version_to_rebel.rb
@@ -1,0 +1,5 @@
+class AddVersionToRebel < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rebels, :version, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_221940) do
+ActiveRecord::Schema.define(version: 2020_02_24_041822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2020_01_31_221940) do
     t.boolean "active", default: true
     t.decimal "lat", precision: 10, scale: 6
     t.decimal "lon", precision: 10, scale: 6
+    t.integer "version"
     t.index ["email_bidx"], name: "index_rebels_on_email_bidx", unique: true
     t.index ["local_group_id"], name: "index_rebels_on_local_group_id"
     t.index ["phone_bidx"], name: "index_rebels_on_phone_bidx"

--- a/lib/tasks/mailtrain.rake
+++ b/lib/tasks/mailtrain.rake
@@ -17,6 +17,7 @@ namespace :mailtrain do
           "MERGE_TAGS": rebel.tags&.pluck(:name)&.join("|"),
           "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
           "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
+          "MERGE_VERSION": rebel.version,
           "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
         }
       )

--- a/lib/tasks/mailtrain.rake
+++ b/lib/tasks/mailtrain.rake
@@ -9,7 +9,7 @@ namespace :mailtrain do
         {
           "EMAIL": rebel.email,
           "MERGE_NAME": rebel.name,
-          "MERGE_SUBSCRIPTION_DATE": rebel.created_at.to_date.to_s,
+          "MERGE_SUBSCRIPTION_DATE": rebel.created_at.to_date.strftime("%d/%m/%Y"),
           "MERGE_LOCAL_GROUP": rebel.local_group&.name,
           "MERGE_LANGUAGE": rebel.language,
           "MERGE_POSTCODE": rebel.postcode,

--- a/spec/factories/rebels.rb
+++ b/spec/factories/rebels.rb
@@ -27,6 +27,7 @@
 #  status                     :string
 #  tags                       :text
 #  token                      :string
+#  version                    :integer
 #  willingness_to_be_arrested :boolean
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/test/fixtures/rebels.yml
+++ b/test/fixtures/rebels.yml
@@ -27,6 +27,7 @@
 #  status                     :string
 #  tags                       :text
 #  token                      :string
+#  version                    :integer
 #  willingness_to_be_arrested :boolean
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/test/models/rebel_test.rb
+++ b/test/models/rebel_test.rb
@@ -27,6 +27,7 @@
 #  status                     :string
 #  tags                       :text
 #  token                      :string
+#  version                    :integer
 #  willingness_to_be_arrested :boolean
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null


### PR DESCRIPTION
##### Description
Welcome emails are currently being delivered when a rebel is updated. We want to send welcome emails only on create, but the way Mailtrain works requires us to delete and create new subscriptions when a rebel is updated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Changes don't break existing behavior
- [ ] Tests coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: https://github.com/extinctionrebellion/RebelsManager/issues/185