### PR TITLE
Add 'Version' field to local groups lists on Mailtrain

### DIFF
--- a/app/external_services/mailtrain_service.rb
+++ b/app/external_services/mailtrain_service.rb
@@ -27,6 +27,27 @@ class MailtrainService
     Raven.capture_exception(e)
   end
 
+  def create_field(list_id, params = {})
+    url = "#{ENV['MAILTRAIN_API_ENDPOINT']}/field/#{list_id}?access_token=#{ENV['MAILTRAIN_API_TOKEN']}"
+    RestClient::Request.execute(
+      method:     :post,
+      url:        url,
+      payload:    params,
+      headers:    {
+                    accept: :json,
+                    params: params
+                  }
+    ) do |response, request, result, block|
+      case response.code
+      when 200
+        JSON.parse(response)
+      else
+        response.return!(&block)
+      end
+    end
+  rescue => e
+    Raven.capture_exception(e)
+  end
 
   def delete_subscription(list_id, params = {})
     url = "#{ENV['MAILTRAIN_API_ENDPOINT']}/delete/#{list_id}?access_token=#{ENV['MAILTRAIN_API_TOKEN']}"

--- a/app/jobs/mailtrain/add_subscriptions_job.rb
+++ b/app/jobs/mailtrain/add_subscriptions_job.rb
@@ -42,6 +42,7 @@ class Mailtrain::AddSubscriptionsJob < ActiveJob::Base
         "MERGE_TAGS": rebel.tags&.pluck(:name)&.join("|"),
         "MERGE_SKILLS": rebel.skills&.pluck(:code)&.join("|"),
         "MERGE_WORKING_GROUPS": rebel.working_groups&.pluck(:code)&.join("|"),
+        "MERGE_VERSION": rebel.version,
         "FORCE_SUBSCRIBE": "yes",
         "TIMEZONE": ENV['XR_BRANCH_TIMEZONE']
       }

--- a/lib/tasks/mailtrain.rake
+++ b/lib/tasks/mailtrain.rake
@@ -97,4 +97,18 @@ namespace :mailtrain do
       end
     end
   end
+
+  desc "Add the 'version' custom field to local groups lists"
+  task add_version_field_to_local_groups_lists: :environment do
+    LocalGroup.where.not(mailtrain_list_id: nil).each do |local_group|
+      MailtrainService.instance.create_field(
+        local_group.mailtrain_list_id,
+        {
+          "NAME": "Version"
+          "TYPE": "text",
+          "VISIBLE": "no"
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
##### Description
We add a 'Version' custom field to the Mailtrain list. Then, each time the rebel updates her profile, we increase the 'Version' value. We can use this custom field to check if a rebel is 'new' (eg. to send a welcome email) or not.