### PR TITLE
Add job to send the welcome mail as a transactional email

### DIFF
--- a/app/external_services/mailtrain_service.rb
+++ b/app/external_services/mailtrain_service.rb
@@ -131,10 +131,10 @@ class MailtrainService
     RestClient::Request.execute(
       method:     :post,
       url:        url,
-      payload:    params.merge({ "SEND_CONFIGURATION_ID": 2 }),
+      payload:    params,
       headers:    {
                     accept: :json,
-                    params: params.merge({ "SEND_CONFIGURATION_ID": 2 })
+                    params: params
                   }
     ) do |response, request, result, block|
       case response.code

--- a/app/jobs/mailtrain/add_registration_job.rb
+++ b/app/jobs/mailtrain/add_registration_job.rb
@@ -29,7 +29,8 @@ class Mailtrain::AddRegistrationJob < ActiveJob::Base
         template_id,
         {
           "EMAIL": registration.email,
-          "SUBJECT": subject
+          "SUBJECT": subject,
+          "SEND_CONFIGURATION_ID": 2
         }
       )
     end

--- a/app/jobs/mailtrain/send_welcome_email_job.rb
+++ b/app/jobs/mailtrain/send_welcome_email_job.rb
@@ -1,0 +1,33 @@
+class Mailtrain::SendWelcomeEmailJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(rebel)
+    send_welcome_email(rebel)
+  end
+
+  private
+
+  def send_welcome_email(rebel)
+    template_id = nil
+    case rebel.language
+    when "en"
+      template_id = 77
+      subject = "Welcome to the rebellion! ⏳🌎"
+    when "fr"
+      template_id = 76
+      subject = "Bienvenue dans la rébellion! ⏳🌎"
+    when "nl"
+      template_id = 78
+      subject = "Welkom bij de opstand! ⏳🌎"
+    end
+    if !template_id.nil?
+      MailtrainService.instance.send_transactional_email(
+        template_id,
+        {
+          "EMAIL": rebel.email,
+          "SUBJECT": subject
+        }
+      )
+    end
+  end
+end

--- a/app/jobs/mailtrain/send_welcome_email_job.rb
+++ b/app/jobs/mailtrain/send_welcome_email_job.rb
@@ -12,20 +12,24 @@ class Mailtrain::SendWelcomeEmailJob < ActiveJob::Base
     case rebel.language
     when "en"
       template_id = 77
-      subject = "Welcome to the rebellion! ⏳🌎"
+      subject = "Welcome to the rebellion!"
     when "fr"
       template_id = 76
-      subject = "Bienvenue dans la rébellion! ⏳🌎"
+      subject = "Bienvenue dans la rébellion!"
     when "nl"
       template_id = 78
-      subject = "Welkom bij de opstand! ⏳🌎"
+      subject = "Welkom bij de opstand!"
     end
     if !template_id.nil?
       MailtrainService.instance.send_transactional_email(
         template_id,
         {
           "EMAIL": rebel.email,
-          "SUBJECT": subject
+          "SUBJECT": subject,
+          "SEND_CONFIGURATION_ID": 4,
+          "TAGS": {
+            "MERGE_PROFILE_URL": rebel.profile_url
+          }
         }
       )
     end

--- a/app/services/rebels/create_service.rb
+++ b/app/services/rebels/create_service.rb
@@ -39,6 +39,7 @@ module Rebels
       delete_existing_rebel_if_no_local_group(@rebel.email)
       @rebel.save!
       Mailtrain::AddSubscriptionsJob.perform_later(@rebel)
+      Mailtrain::SendWelcomeEmailJob.perform_later(@rebel)
       GeocodeRebelJob.perform_later(@rebel) if @rebel.postcode.present?
       true
     end


### PR DESCRIPTION
##### Description
Welcome emails are not always sent by Mailtrain, and we have no one to work on this issue. Let's move to transactional emails.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Testing

* Welcome email is delivered when joining XR Belgium